### PR TITLE
Fixed NODE_SET_METHOD for node v0.11.x.

### DIFF
--- a/node-gumbo.cc
+++ b/node-gumbo.cc
@@ -171,7 +171,8 @@ Handle<Value> Method(const Arguments& args) {
 } 
 
 void init(Handle<Object> exports) {
-    NODE_SET_METHOD(exports, "gumbo", Method);
+    exports->Set(String::NewSymbol("gumbo"),
+      FunctionTemplate::New(Method)->GetFunction());
 }
 
 NODE_MODULE(binding, init);


### PR DESCRIPTION
This was tested on Node v0.11.7 and v0.10.16 and both work and tests pass successfully.

Signed-off-by: Daniel Fagnan dnfagnan@gmail.com
