### PR TITLE
Adding a couple of xcode flags

### DIFF
--- a/deps/gumbo-parser/gumbo-parser.gyp
+++ b/deps/gumbo-parser/gumbo-parser.gyp
@@ -35,6 +35,11 @@
        'target_name': 'gumbo',
        'product_prefix': 'lib',
        'type': 'static_library',
+       'xcode_settings': {
+          'OTHER_CFLAGS': [
+            '-Wall', '-Wno-sign-compare', '-std=gnu99'
+          ],
+        },
        'sources': [
             'src/attribute.c',
             'src/attribute.h',


### PR DESCRIPTION
-Wno-sign-compare kills a bunch of warning
-std=gnu99 fixes #7 (build on snow leopard)
